### PR TITLE
Resolve parser ambiguity

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -9,22 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add CompatHelper
-        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
+        run: julia --color=yes -e 'using Pkg; Pkg.add("CompatHelper")'
       - name: Run CompatHelper
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: julia -e '
-                using CompatHelper, Pkg;
-                my_registries = [
-                    Pkg.RegistrySpec(
-                        name = "BioJuliaRegistry",
-                        uuid = "ccbd2cc2-2954-11e9-1ccf-f3e7900901ca",
-                        url = "https://github.com/BioJulia/BioJuliaRegistry.git"
-                    ),
-                    Pkg.RegistrySpec(
-                        name = "General",
-                        uuid = "23338594-aafe-5451-b93e-139f81909106",
-                        url = "https://github.com/JuliaRegistries/General.git"
-                    )
-                ];
-                CompatHelper.main(; registries = my_registries, master_branch = "master");'
+          COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}
+        run: julia --color=yes -e 'using CompatHelper; CompatHelper.main(master_branch = "master")'

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -14,16 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@latest
+      - uses: julia-actions/setup-julia@v1
         with:
           version: '1.4'
       - name: Install dependencies
-        run: |
-          julia ci_prep.jl;
-          julia --color=yes --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+        run: julia --color=yes --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy
         env:
-          # https://github.com/JuliaDocs/Documenter.jl/issues/1177
           # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key
         run: julia --color=yes --project=docs/ docs/make.jl

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,7 +1,7 @@
 name: TagBot
 on:
   schedule:
-    - cron: '0 * * * *'
+    - cron: 0 0 * * *
 jobs:
   TagBot:
     runs-on: ubuntu-latest
@@ -10,4 +10,3 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ssh: ${{ secrets.TAGBOT_KEY }}
-          registry: BioJulia/BioJuliaRegistry

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -6,22 +6,19 @@ on:
 
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        version: ['1.1', '1.2', '1.3', '1.4']
-        arch: [x64]
+        julia-version: ['1.1', '1.2', '1.3', '1.4']
+        julia-arch: [x86]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
       - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - name: Setup
+        uses: julia-actions/setup-julia@v1
         with:
-          version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-      - name: Install dependencies
-        run: julia ci_prep.jl
+          version: ${{ matrix.julia-version }}
       - name: Run tests
         uses: julia-actions/julia-runtest@latest
       - name: Create CodeCov

--- a/README.md
+++ b/README.md
@@ -10,20 +10,13 @@
 > This project follows the [semver](http://semver.org) pro forma and uses the [git-flow branching model](https://nvie.com/posts/a-successful-git-branching-model/ "original blog post").
 
 ## Description
-This package provides data representation and IO tools for the bigBed file format.
+The BigBed package provides data representation and IO tools for the bigBed file format.
 The bigBed binary file format is for representing genomic annotations.
 It is indexed to fetch specific regions quickly and is often created from BED files.
 
 ## Installation
-The latest version of BigBed is made available to install through BioJulia's package registry.
-By default, Julia's package manager only includes the "General" package registry.
-
-To add the BioJulia registry from the [Julia REPL](https://docs.julialang.org/en/v1/manual/getting-started/), press `]` to enter [pkg mode](https://docs.julialang.org/en/v1/stdlib/Pkg/), then enter the following command:
-```julia
-registry add https://github.com/BioJulia/BioJuliaRegistry.git
-```
-
-Once the registry is added to your configuration, you can install BigBed while in [pkg mode](https://docs.julialang.org/en/v1/stdlib/Pkg/) with the following:
+You can install the BigBed package from the [Julia REPL](https://docs.julialang.org/en/v1/manual/getting-started/).
+Press `]` to enter [pkg mode](https://docs.julialang.org/en/v1/stdlib/Pkg/), then enter the following command:
 ```julia
 add BigBed
 ```

--- a/ci_prep.jl
+++ b/ci_prep.jl
@@ -1,3 +1,0 @@
-using Pkg.Registry
-Registry.add(Registry.RegistrySpec(url = "https://github.com/BioJulia/BioJuliaRegistry.git"))
-Registry.add(Registry.RegistrySpec(url = "https://github.com/JuliaRegistries/General.git"))

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -11,20 +11,13 @@
 > This project follows the [semver](http://semver.org) pro forma and uses the [git-flow branching model](https://nvie.com/posts/a-successful-git-branching-model/).
 
 ## Description
-This package provides data representation and IO tools for the bigBed file format.
+The BigBed package provides data representation and IO tools for the bigBed file format.
 The bigBed binary file format is for representing genomic annotations.
 It is indexed to fetch specific regions quickly and is often created from BED files.
 
 ## Installation
-The latest version of BigBed is made available to install through BioJulia's package registry.
-By default, Julia's package manager only includes the "General" package registry.
-
-To add the BioJulia registry from the [Julia REPL](https://docs.julialang.org/en/v1/manual/getting-started/), press `]` to enter [pkg mode](https://docs.julialang.org/en/v1/stdlib/Pkg/), then enter the following command:
-```julia
-registry add https://github.com/BioJulia/BioJuliaRegistry.git
-```
-
-Once the registry is added to your configuration, you can install BigBed while in [pkg mode](https://docs.julialang.org/en/v1/stdlib/Pkg/) with the following:
+You can install the BigBed package from the [Julia REPL](https://docs.julialang.org/en/v1/manual/getting-started/).
+Press `]` to enter [pkg mode](https://docs.julialang.org/en/v1/stdlib/Pkg/), then enter the following command:
 ```julia
 add BigBed
 ```

--- a/src/BigBed.jl
+++ b/src/BigBed.jl
@@ -17,7 +17,7 @@ import Automa.RegExp: @re_str
 import BufferedStreams
 import ColorTypes
 import FixedPointNumbers: N0f8
-import GenomicFeatures: GenomicFeatures, Interval
+import GenomicFeatures: GenomicFeatures, Interval, seqname, leftposition, rightposition
 import Libz
 
 

--- a/src/overlap.jl
+++ b/src/overlap.jl
@@ -17,12 +17,12 @@ function Base.IteratorSize(::Type{OverlapIterator})
 end
 
 function GenomicFeatures.eachoverlap(reader::Reader, interval::GenomicFeatures.Interval)
-    if haskey(reader.chroms, interval.seqname)
-        id, _ = reader.chroms[interval.seqname]
+    if haskey(reader.chroms, seqname(interval))
+        id, _ = reader.chroms[seqname(interval)]
     else
         id = typemax(UInt32)
     end
-    return OverlapIterator(reader, id, interval.first - 1, interval.last)
+    return OverlapIterator(reader, id, leftposition(interval) - 1, rightposition(interval))
 end
 
 mutable struct OverlapIteratorState

--- a/src/reader.jl
+++ b/src/reader.jl
@@ -76,7 +76,7 @@ const data_machine = (function ()
         chromend = re"...."
         chromend.actions[:exit] = [:record_chromend]
 
-        name = re"[ -~]*"
+        name = re"[ -~]+"
         name.actions[:enter] = [:mark]
         name.actions[:exit]  = [:record_name]
 

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -148,13 +148,13 @@ function Base.write(writer::Writer, record::Tuple{String,Integer,Integer,Vararg}
 end
 
 function Base.write(writer::Writer, interval::GenomicFeatures.Interval{Nothing})
-    chromid = writer.chroms[interval.seqname][1]
-    return write_impl(writer, chromid, UInt32(interval.first - 1), UInt32(interval.last), ())
+    chromid = writer.chroms[seqname(interval)][1]
+    return write_impl(writer, chromid, UInt32(leftposition(interval) - 1), UInt32(rightposition(interval)), ())
 end
 
 function Base.write(writer::Writer, interval::GenomicFeatures.Interval{T}) where T<:Tuple
-    chromid = writer.chroms[interval.seqname][1]
-    return write_impl(writer, chromid, UInt32(interval.first - 1), UInt32(interval.last), interval.metadata...)
+    chromid = writer.chroms[seqname(interval)][1]
+    return write_impl(writer, chromid, UInt32(leftposition(interval) - 1), UInt32(rightposition(interval)), GenomicFeatures.metadata(interval)...)
 end
 
 function Base.close(writer::Writer)
@@ -362,7 +362,7 @@ function compute_section_summary(intervals::Vector{Interval{Nothing}})
     sum = 0.0
     ssq = 0.0
     for range in GenomicFeatures.coverage(intervals)
-        depth = range.metadata
+        depth = GenomicFeatures.metadata(range)
         size = range.last - range.first + 1
         cov += size
         min = Base.min(min, depth)


### PR DESCRIPTION
I want to push https://github.com/BioJulia/Automa.jl/pull/49, and am in the process of checking all packages that depend on Automa for whether that commit introduces errors.

In BigBed, it's not possible for the parser to determine whether a record like `b"\0\0\0\1\0\0\0\1\0\0\0\1\0"` contains a name or not, and the actions it should take are therefore ambiguous.

This change fixes that.